### PR TITLE
Manually get `XDG_CONFIG_HOME` and drop pyxdg from dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && apt install -y \
     apt install -y xvfb && \
     rm -rf /var/lib/apt/lists/* && apt clean
 
-RUN pip3 install gatt pyxdg requests black
+RUN pip3 install gatt requests black
 
 COPY . /siglo
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Gtk >= 3.30
 
 ```sh
 sudo pacman -S --needed meson python-pip base-devel bluez bluez-utils dbus-python python-gobject
-pip3 install gatt pyxdg
+pip3 install gatt
 ```
 
 ### Fedora
@@ -28,7 +28,7 @@ pip3 install gatt
 
 ```sh
 sudo apt install libgtk-3-dev python3-pip meson python3-dbus gtk-update-icon-cache desktop-file-utils gettext appstream-util libglib2.0-dev
-pip3 install gatt pyxdg requests black
+pip3 install gatt requests black
 ```
 
 ## Build/Install

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -64,20 +64,6 @@
                     "sha256": "b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
                 }
             ]
-        },
-        {
-            "name": "python3-pyxdg",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyxdg\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/6f/2e/2251b5ae2f003d865beef79c8fcd517e907ed6a69f58c32403cec3eba9b2/pyxdg-0.27.tar.gz",
-                    "sha256": "80bd93aae5ed82435f20462ea0208fb198d8eec262e831ee06ce9ddb6b91c5a5"
-                }
-            ]
         }
     ]
 }

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,7 @@
 import configparser
-import xdg.BaseDirectory
 import distutils
 import distutils.util
+import os
 from pathlib import Path
 
 
@@ -13,8 +13,10 @@ class config:
         "paired": "False",
         "adapter": "None",
     }
-    config_dir = xdg.BaseDirectory.xdg_config_home
-    config_file = config_dir + "/siglo.ini"
+    config_dir = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
+        os.path.expanduser("~"), ".config"
+    )
+    config_file = os.path.join(config_dir, "siglo.ini")
 
     def load_defaults(self):
         if not Path(self.config_dir).is_dir():


### PR DESCRIPTION
Drop `pyxdg` as dependency and instead get `XDG_CONFIG_HOME` manually.
The same way is being used as `pyxdg` does:
https://gitlab.freedesktop.org/xdg/pyxdg/-/blob/bd999c1c/xdg/BaseDirectory.py#L37-L38

There is a name clash between the two packages `xdg` and `pyxdg`. See:
https://gitlab.freedesktop.org/xdg/pyxdg/-/issues/24

As only that one environment variable is being used from the library
it can just as good be expanded manually.
This solves the confusion and problems for users who have both
installed and it also reduces the dependency footprint.

Also use `os.path.join` for `config_file`.